### PR TITLE
Add the ability to select the debugger engines to connect to

### DIFF
--- a/WacVsTools.2017.sln
+++ b/WacVsTools.2017.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WacVsTools.Core", "src\WacVsTools.Core\WacVsTools.Core.csproj", "{B6D87720-D855-4E62-94E5-EC1BC820C727}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WacVsTools.VS2017", "src\WacVsTools.VS2017\WacVsTools.VS2017.csproj", "{0CB92AF2-18E7-4D31-A27D-7CB599514AE2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WacVsTools.Test", "WacVsTools.Test\WacVsTools.Test.csproj", "{A394298C-A036-4B1D-A0FF-6303E0A26CED}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,8 +23,15 @@ Global
 		{0CB92AF2-18E7-4D31-A27D-7CB599514AE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0CB92AF2-18E7-4D31-A27D-7CB599514AE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0CB92AF2-18E7-4D31-A27D-7CB599514AE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A394298C-A036-4B1D-A0FF-6303E0A26CED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A394298C-A036-4B1D-A0FF-6303E0A26CED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A394298C-A036-4B1D-A0FF-6303E0A26CED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A394298C-A036-4B1D-A0FF-6303E0A26CED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4BAE8CCF-D01C-4854-A87E-5095C12EE7A1}
 	EndGlobalSection
 EndGlobal

--- a/WacVsTools.Test/App.config
+++ b/WacVsTools.Test/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/WacVsTools.Test/App.xaml
+++ b/WacVsTools.Test/App.xaml
@@ -1,0 +1,4 @@
+﻿<Application x:Class="WacVsTools.Test.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+</Application>

--- a/WacVsTools.Test/App.xaml.cs
+++ b/WacVsTools.Test/App.xaml.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using WacVsTools.Core.AttachToWacProcess;
+
+namespace WacVsTools.Test
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            var processes = new List<WacProcessInfo>()
+            {
+                new WacProcessInfo() { Id = 1, App = "Test", CommandLine = "command line", Name = "Test" },
+            };
+
+            var model = new AttachToWacProcessDialogModel(new TestMenuCommands(), processes);
+            var window = new AttachToWacProcessDialog(model);
+            window.ShowDialog();
+        }
+    }
+
+    internal sealed class TestMenuCommands : IMenuCommands
+    {
+        public DebuggerEngines ShowSelectDebuggerEngineDialog(DebuggerEngines current)
+        {
+            if (current.IsLazy)
+            {
+                current = new DebuggerEngines(isAutomatic: true, manualSelection: SelectDebuggerEngineDialogModelDesignSample.SampleEngines);
+            }
+
+            var model = new SelectDebuggerEngineDialogModel(current);
+            var window = new SelectDebuggerEngineDialog(model);
+            return window.ShowDialog().GetValueOrDefault(false) ? model.DebuggerEngines : current;
+        }
+    }
+}

--- a/WacVsTools.Test/Properties/AssemblyInfo.cs
+++ b/WacVsTools.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,55 @@
+﻿using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WacVsTools.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WacVsTools.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+//In order to begin building localizable applications, set
+//<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
+//inside a <PropertyGroup>.  For example, if you are using US english
+//in your source files, set the <UICulture> to en-US.  Then uncomment
+//the NeutralResourceLanguage attribute below.  Update the "en-US" in
+//the line below to match the UICulture setting in the project file.
+
+//[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
+
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]
+
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/WacVsTools.Test/WacVsTools.Test.csproj
+++ b/WacVsTools.Test/WacVsTools.Test.csproj
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A394298C-A036-4B1D-A0FF-6303E0A26CED}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>WacVsTools.Test</RootNamespace>
+    <AssemblyName>WacVsTools.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <WarningLevel>4</WarningLevel>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Compile Include="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Properties\Resources.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\Settings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
+    <EmbeddedResource Include="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <None Include="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\WacVsTools.Core\WacVsTools.Core.csproj">
+      <Project>{b6d87720-d855-4e62-94e5-ec1bc820c727}</Project>
+      <Name>WacVsTools.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/WacVsTools.Test/WacVsTools.Test.csproj
+++ b/WacVsTools.Test/WacVsTools.Test.csproj
@@ -63,24 +63,6 @@
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialog.xaml
+++ b/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialog.xaml
@@ -2,9 +2,13 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Attach to WAC Process" Height="400" Width="700" WindowStartupLocation="CenterOwner" ResizeMode="NoResize" >
+    <Window.Resources>
+        <ResourceDictionary Source="Resources.xaml"/>
+    </Window.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="223*"/>
+            <RowDefinition Height="46*"/>
             <RowDefinition Height="46*"/>
         </Grid.RowDefinitions>
         <DataGrid x:Name="Processes" AutoGenerateColumns="False" ItemsSource="{Binding Processes}"
@@ -19,13 +23,25 @@
         </DataGrid>
         <Grid Grid.Row="1" VerticalAlignment="Center">
             <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="auto" />
             </Grid.ColumnDefinitions>
-                <TextBlock x:Name="NoRecordsError" FontWeight="Bold" HorizontalAlignment="Left" Text="It's empty here. Are you sure WAC is running on your box?" Foreground="Red" IsEnabled="False" />
-                <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button Name="btnOk" Click="btnOk_Click" IsDefault="True" Height="25" Width="90" IsEnabled="False">Attach</Button>
-                <Button Name="btnCancel" Click="btnCancel_Click" Margin="10,0,0,0" IsCancel="True" Height="25" Width="90">Cancel</Button>
+            <TextBlock Text="Attach to:" Margin="0,0,20,0" />
+            <TextBox Grid.Column="1" MinWidth="250" IsEnabled="False" Text="{Binding DebuggerEngines, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" x:Name="SelectedEngines" />
+            <Button Grid.Column="2" x:Name="SelectEngines" Click="SelectEngines_Click">
+                <AccessText>_Select...</AccessText>
+            </Button>
+        </Grid>
+        <Grid Grid.Row="2" VerticalAlignment="Center">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Name="NoRecordsError" FontWeight="Bold" HorizontalAlignment="Left" Text="It's empty here. Are you sure WAC is running on your box?" Foreground="Red" IsEnabled="False" />
+            <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Name="btnOk" Click="btnOk_Click" IsDefault="True" IsEnabled="False">Attach</Button>
+                <Button Name="btnCancel" Click="btnCancel_Click" IsCancel="True">Cancel</Button>
             </StackPanel>
         </Grid>
     </Grid>

--- a/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialog.xaml.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialog.xaml.cs
@@ -1,20 +1,24 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
-
-namespace WacVsTools.Core.AttachToWacProcess
+﻿namespace WacVsTools.Core.AttachToWacProcess
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Windows;
+    using System.Windows.Controls;
+
     public partial class AttachToWacProcessDialog : Window
     {
-        List<int> selectedProcesses;
+        private AttachToWacProcessDialogModel m_model;
+        private HashSet<int> m_selectedProcesses;
 
         public AttachToWacProcessDialog(AttachToWacProcessDialogModel model)
         {
-            selectedProcesses = new List<int>();
-            model.SelectedProcesses = selectedProcesses;
+            m_model = model ?? throw new ArgumentNullException(nameof(model));
 
-            this.DataContext = model;
+            m_selectedProcesses = new HashSet<int>();
+            model.SelectedProcesses = m_selectedProcesses;
+
+            this.DataContext = m_model;
 
             InitializeComponent();
 
@@ -23,11 +27,11 @@ namespace WacVsTools.Core.AttachToWacProcess
 
         private void Processes_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            selectedProcesses.AddRange(e.AddedItems.Cast<WacProcessInfo>().Select(x => x.Id));
+            m_selectedProcesses.UnionWith(e.AddedItems.Cast<WacProcessInfo>().Select(x => x.Id));
             foreach (var removedItem in e.RemovedItems.Cast<WacProcessInfo>())
-                selectedProcesses.Remove(removedItem.Id);
+                m_selectedProcesses.Remove(removedItem.Id);
 
-            btnOk.IsEnabled = selectedProcesses.Count > 0;
+            btnOk.IsEnabled = m_selectedProcesses.Count > 0;
         }
 
         private void btnOk_Click(object sender, RoutedEventArgs e)
@@ -42,19 +46,24 @@ namespace WacVsTools.Core.AttachToWacProcess
             Close();
         }
 
-		private void Processes_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
-		{
-			var grid = sender as DataGrid;
-			var selectedProcessInfo = grid.SelectedItem as WacProcessInfo;
+        private void Processes_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            var grid = sender as DataGrid;
+            var selectedProcessInfo = grid.SelectedItem as WacProcessInfo;
 
-			if (selectedProcessInfo != null)
-			{
-				selectedProcesses.Clear();
-				selectedProcesses.Add(selectedProcessInfo.Id);
+            if (selectedProcessInfo != null)
+            {
+                m_selectedProcesses.Clear();
+                m_selectedProcesses.Add(selectedProcessInfo.Id);
 
-				DialogResult = true;
-				Close();
-			}
-		}
-	}
+                DialogResult = true;
+                Close();
+            }
+        }
+
+        private void SelectEngines_Click(object sender, RoutedEventArgs e)
+        {
+            m_model.DebuggerEngines = m_model.MenuCommands.ShowSelectDebuggerEngineDialog(m_model.DebuggerEngines.Clone());
+        }
+    }
 }

--- a/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialog.xaml.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialog.xaml.cs
@@ -8,17 +8,17 @@
 
     public partial class AttachToWacProcessDialog : Window
     {
-        private AttachToWacProcessDialogModel m_model;
-        private HashSet<int> m_selectedProcesses;
+        private AttachToWacProcessDialogModel model;
+        private HashSet<int> selectedProcesses;
 
         public AttachToWacProcessDialog(AttachToWacProcessDialogModel model)
         {
-            m_model = model ?? throw new ArgumentNullException(nameof(model));
+            this.model = model ?? throw new ArgumentNullException(nameof(model));
 
-            m_selectedProcesses = new HashSet<int>();
-            model.SelectedProcesses = m_selectedProcesses;
+            selectedProcesses = new HashSet<int>();
+            model.SelectedProcesses = selectedProcesses;
 
-            this.DataContext = m_model;
+            this.DataContext = this.model;
 
             InitializeComponent();
 
@@ -27,11 +27,11 @@
 
         private void Processes_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            m_selectedProcesses.UnionWith(e.AddedItems.Cast<WacProcessInfo>().Select(x => x.Id));
+            selectedProcesses.UnionWith(e.AddedItems.Cast<WacProcessInfo>().Select(x => x.Id));
             foreach (var removedItem in e.RemovedItems.Cast<WacProcessInfo>())
-                m_selectedProcesses.Remove(removedItem.Id);
+                selectedProcesses.Remove(removedItem.Id);
 
-            btnOk.IsEnabled = m_selectedProcesses.Count > 0;
+            btnOk.IsEnabled = selectedProcesses.Count > 0;
         }
 
         private void btnOk_Click(object sender, RoutedEventArgs e)
@@ -53,8 +53,8 @@
 
             if (selectedProcessInfo != null)
             {
-                m_selectedProcesses.Clear();
-                m_selectedProcesses.Add(selectedProcessInfo.Id);
+                selectedProcesses.Clear();
+                selectedProcesses.Add(selectedProcessInfo.Id);
 
                 DialogResult = true;
                 Close();
@@ -63,7 +63,7 @@
 
         private void SelectEngines_Click(object sender, RoutedEventArgs e)
         {
-            m_model.DebuggerEngines = m_model.MenuCommands.ShowSelectDebuggerEngineDialog(m_model.DebuggerEngines.Clone());
+            model.DebuggerEngines = model.MenuCommands.ShowSelectDebuggerEngineDialog(model.DebuggerEngines.Clone());
         }
     }
 }

--- a/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialogModel.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialogModel.cs
@@ -1,11 +1,56 @@
-﻿using System.Collections.Generic;
-
-namespace WacVsTools.Core.AttachToWacProcess
+﻿namespace WacVsTools.Core.AttachToWacProcess
 {
-    public class AttachToWacProcessDialogModel
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+
+    public class AttachToWacProcessDialogModel : INotifyPropertyChanged
     {
+        private DebuggerEngines m_debuggerEngines;
+
+        public AttachToWacProcessDialogModel(IMenuCommands menuCommands, IList<WacProcessInfo> processes)
+        {
+            MenuCommands = menuCommands ?? throw new ArgumentNullException(nameof(menuCommands));
+            Processes = processes ?? throw new ArgumentNullException(nameof(processes));
+            DebuggerEngines = DebuggerEngines.DefaultLazy;
+        }
+
         public IList<WacProcessInfo> Processes { get; set; }
-        public IEnumerable<int> SelectedProcesses { get; set; }
+
+        public ISet<int> SelectedProcesses { get; set; }
+
+        public DebuggerEngines DebuggerEngines
+        {
+            get
+            {
+                return m_debuggerEngines;
+            }
+            set
+            {
+                if (m_debuggerEngines != value)
+                {
+                    if (m_debuggerEngines != null)
+                    {
+                        m_debuggerEngines.PropertyChanged -= DebuggerEngines_PropertyChanged;
+                    }
+
+                    m_debuggerEngines = value;
+
+                    m_debuggerEngines.PropertyChanged += DebuggerEngines_PropertyChanged;
+
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DebuggerEngines)));
+                }
+            }
+        }
+
+        private void DebuggerEngines_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DebuggerEngines)));
+        }
+
+        public IMenuCommands MenuCommands { get; }
+
+        public event PropertyChangedEventHandler PropertyChanged;
     }
 
     public class WacProcessInfo

--- a/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialogModel.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialogModel.cs
@@ -6,7 +6,7 @@
 
     public class AttachToWacProcessDialogModel : INotifyPropertyChanged
     {
-        private DebuggerEngines m_debuggerEngines;
+        private DebuggerEngines debuggerEngines;
 
         public AttachToWacProcessDialogModel(IMenuCommands menuCommands, IList<WacProcessInfo> processes)
         {
@@ -23,20 +23,20 @@
         {
             get
             {
-                return m_debuggerEngines;
+                return debuggerEngines;
             }
             set
             {
-                if (m_debuggerEngines != value)
+                if (debuggerEngines != value)
                 {
-                    if (m_debuggerEngines != null)
+                    if (debuggerEngines != null)
                     {
-                        m_debuggerEngines.PropertyChanged -= DebuggerEngines_PropertyChanged;
+                        debuggerEngines.PropertyChanged -= DebuggerEngines_PropertyChanged;
                     }
 
-                    m_debuggerEngines = value;
+                    debuggerEngines = value;
 
-                    m_debuggerEngines.PropertyChanged += DebuggerEngines_PropertyChanged;
+                    debuggerEngines.PropertyChanged += DebuggerEngines_PropertyChanged;
 
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DebuggerEngines)));
                 }

--- a/src/WacVsTools.Core/AttachToWacProcess/IMenuCommands.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/IMenuCommands.cs
@@ -1,0 +1,7 @@
+﻿namespace WacVsTools.Core.AttachToWacProcess
+{
+    public interface IMenuCommands
+    {
+        DebuggerEngines ShowSelectDebuggerEngineDialog(DebuggerEngines current);
+    }
+}

--- a/src/WacVsTools.Core/AttachToWacProcess/Resources.xaml
+++ b/src/WacVsTools.Core/AttachToWacProcess/Resources.xaml
@@ -1,0 +1,9 @@
+﻿<ResourceDictionary x:Class="WacVsTools.Core.AttachToWacProcess.Resources"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style TargetType="Button">
+        <Setter Property="Width" Value="90" />
+        <Setter Property="Height" Value="25" />
+        <Setter Property="Margin" Value="10,0,0,0" />
+    </Style>
+</ResourceDictionary>

--- a/src/WacVsTools.Core/AttachToWacProcess/SelectDebuggerEngineDialog.xaml
+++ b/src/WacVsTools.Core/AttachToWacProcess/SelectDebuggerEngineDialog.xaml
@@ -1,0 +1,62 @@
+﻿<Window x:Class="WacVsTools.Core.AttachToWacProcess.SelectDebuggerEngineDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:UI="clr-namespace:WacVsTools.Core.AttachToWacProcess"
+        d:DataContext="{d:DesignInstance Type=UI:SelectDebuggerEngineDialogModelDesignSample, IsDesignTimeCreatable=True}"
+        Title="Select Code Type" Height="250" Width="470" WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <Style TargetType="RadioButton">
+                <Setter Property="Margin" Value="0,10,0,0" />
+            </Style>
+            <Style TargetType="ListBox">
+                <Setter Property="Margin" Value="20,10,0,10" />
+                <Setter Property="ItemContainerStyle">
+                    <Setter.Value>
+                        <Style TargetType="ListBoxItem">
+                            <Setter Property="Margin" Value="2,2,2,2"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="ListBoxItem">
+                                        <ContentPresenter/>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="auto"/>
+        </Grid.RowDefinitions>
+        <RadioButton Grid.Row="0" Name="SelectAutomatically" IsChecked="{Binding Path=DebuggerEngines.IsAutomatic, Mode=TwoWay}">Automatically determine the type of code to debug</RadioButton>
+        <RadioButton Grid.Row="1" Name="SelectManually" IsChecked="{Binding Path=DebuggerEngines.IsManual, Mode=TwoWay}">Debug these code types:</RadioButton>
+        <ListBox Grid.Row="2"
+                 SelectionMode="Multiple"
+                 ItemsSource="{Binding Path=DebuggerEngines.ManualSelection}"
+                 IsEnabled="{Binding ElementName=SelectManually, Path=IsChecked}"
+                 Name="AvailableEngines">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <CheckBox Content="{Binding Path=Name}" IsChecked="{Binding Path=IsSelected}"/>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Name="btnOk" IsDefault="True" IsEnabled="{Binding Path=SelectionValid}" Click="btnOk_Click">OK</Button>
+            <Button Name="btnCancel" IsCancel="True" Click="btnCancel_Click">Cancel</Button>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/WacVsTools.Core/AttachToWacProcess/SelectDebuggerEngineDialog.xaml.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/SelectDebuggerEngineDialog.xaml.cs
@@ -8,13 +8,13 @@
     /// </summary>
     public partial class SelectDebuggerEngineDialog : Window
     {
-        ISelectDebuggerEngineDialogModel m_model;
+        ISelectDebuggerEngineDialogModel model;
 
         public SelectDebuggerEngineDialog(ISelectDebuggerEngineDialogModel model)
         {
-            m_model = model ?? throw new ArgumentNullException(nameof(model));
+            this.model = model ?? throw new ArgumentNullException(nameof(model));
 
-            DataContext = m_model;
+            DataContext = this.model;
 
             InitializeComponent();
         }

--- a/src/WacVsTools.Core/AttachToWacProcess/SelectDebuggerEngineDialog.xaml.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/SelectDebuggerEngineDialog.xaml.cs
@@ -1,0 +1,34 @@
+﻿namespace WacVsTools.Core.AttachToWacProcess
+{
+    using System;
+    using System.Windows;
+
+    /// <summary>
+    /// Interaction logic for SelectDebuggerEngine.xaml
+    /// </summary>
+    public partial class SelectDebuggerEngineDialog : Window
+    {
+        ISelectDebuggerEngineDialogModel m_model;
+
+        public SelectDebuggerEngineDialog(ISelectDebuggerEngineDialogModel model)
+        {
+            m_model = model ?? throw new ArgumentNullException(nameof(model));
+
+            DataContext = m_model;
+
+            InitializeComponent();
+        }
+
+        private void btnOk_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void btnCancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/src/WacVsTools.Core/AttachToWacProcess/SelectDebuggerEngineDialogModel.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/SelectDebuggerEngineDialogModel.cs
@@ -1,0 +1,248 @@
+﻿namespace WacVsTools.Core.AttachToWacProcess
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Linq;
+
+    using Microsoft.Win32;
+
+    public interface ISelectDebuggerEngineDialogModel
+    {
+        DebuggerEngines DebuggerEngines { get; set; }
+
+        bool SelectionValid { get; }
+    }
+
+    public sealed class DebuggerEngines : INotifyPropertyChanged
+    {
+        private const string RegistryKeyPath = @"SOFTWARE\Microsoft\WAC\WacVsTools";
+        private const string IsAutomaticValueName = @"IsAutomatic";
+        private const string ManuallySelectedEnginesValueName = @"ManuallySelectedEngines";
+
+        public const string DefaultDebuggerEngineName = @"Managed (v4.6, v4.5, v4.0) code";
+        public const string DefaultDebuggerEngineID = @"{FB0D4648-F776-4980-95F8-BB7F36EBC1EE}";
+
+        private static readonly DebuggerEngines s_default = new DebuggerEngines(isLazy: true, isAutomatic: true, manualSelection: new[] { new DebuggerEngine(DefaultDebuggerEngineName, DefaultDebuggerEngineID, isSelected: false) });
+
+        private readonly bool m_isLazy;
+        private bool m_isAutomatic;
+        private readonly IReadOnlyList<DebuggerEngine> m_manualSelection;
+
+        public DebuggerEngines(bool isAutomatic, IList<DebuggerEngine> manualSelection)
+            : this(isLazy: false, isAutomatic: isAutomatic, manualSelection: manualSelection)
+        {
+        }
+
+        private DebuggerEngines(bool isLazy, bool isAutomatic, IList<DebuggerEngine> manualSelection)
+        {
+            m_isLazy = isLazy;
+            IsAutomatic = isAutomatic;
+            m_manualSelection = manualSelection?.ToList() ?? throw new ArgumentNullException(nameof(ManualSelection));
+
+            foreach (var debuggerEngine in m_manualSelection)
+            {
+                debuggerEngine.PropertyChanged += OnChildPropertyChanged;
+            }
+        }
+
+        private void OnChildPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ManualSelection)));
+        }
+
+        public static DebuggerEngines DefaultLazy => s_default;
+
+        public bool IsAutomatic
+        {
+            get
+            {
+                return m_isAutomatic;
+            }
+            set
+            {
+                if (m_isAutomatic != value)
+                {
+                    m_isAutomatic = value;
+
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsAutomatic)));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsManual)));
+                }
+            }
+        }
+
+        public void PersistSelectionToRegistry()
+        {
+            using (var registryKey = Registry.CurrentUser.CreateSubKey(RegistryKeyPath))
+            {
+                registryKey.SetValue(IsAutomaticValueName, IsAutomatic, RegistryValueKind.DWord);
+                registryKey.SetValue(
+                    ManuallySelectedEnginesValueName,
+                    ManuallySelectedEngines.Select(debuggerEngine => debuggerEngine.ID).ToArray(),
+                    RegistryValueKind.MultiString);
+            }
+        }
+
+        public void RestoreSelectionFromRegistry()
+        {
+            using (var registryKey = Registry.CurrentUser.CreateSubKey(RegistryKeyPath))
+            {
+                var valueNames = registryKey.GetValueNames();
+
+                if (valueNames.Contains(IsAutomaticValueName))
+                    IsAutomatic = ((int)registryKey.GetValue(IsAutomaticValueName)) != 0;
+                else
+                    IsAutomatic = true;
+
+                string[] manuallySelectedEngineIds = new string[0];
+                if (valueNames.Contains(ManuallySelectedEnginesValueName))
+                {
+                    manuallySelectedEngineIds = (string[])registryKey.GetValue(ManuallySelectedEnginesValueName);
+                }
+
+                foreach (var debuggerEngine in ManualSelection)
+                {
+                    debuggerEngine.IsSelected = manuallySelectedEngineIds.Contains(debuggerEngine.ID, StringComparer.OrdinalIgnoreCase);
+                }
+            }
+        }
+
+        public bool IsManual // for WPF binding
+        {
+            get
+            {
+                return !m_isAutomatic;
+            }
+            set
+            {
+                if (m_isAutomatic != !value)
+                {
+                    m_isAutomatic = !value;
+
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsAutomatic)));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsManual)));
+                }
+            }
+        }
+
+        public bool IsLazy => m_isLazy;
+
+        public IReadOnlyList<DebuggerEngine> ManualSelection => m_manualSelection;
+
+        public IEnumerable<DebuggerEngine> ManuallySelectedEngines => m_manualSelection.Where(debuggerEngine => debuggerEngine.IsSelected);
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public override string ToString()
+        {
+            return IsAutomatic ? "Automatic: " + DefaultDebuggerEngineName : string.Join(", ", ManuallySelectedEngines);
+        }
+
+        public DebuggerEngines Clone()
+        {
+            return new DebuggerEngines(
+                m_isLazy,
+                m_isAutomatic,
+                m_manualSelection
+                    .Select(debuggerEngine => debuggerEngine.Clone()).ToList());
+        }
+    }
+
+    public sealed class DebuggerEngine : INotifyPropertyChanged, IComparable<DebuggerEngine>
+    {
+        private bool m_isSelected;
+
+        public DebuggerEngine(string name, string id, bool isSelected)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            ID = id ?? throw new ArgumentNullException(nameof(id));
+            IsSelected = isSelected;
+        }
+
+        public string Name { get; }
+
+        public string ID { get; }
+
+        public bool IsSelected
+        {
+            get
+            {
+                return m_isSelected;
+            }
+            set
+            {
+                m_isSelected = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected)));
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public override string ToString()
+        {
+            return Name;
+        }
+
+        public DebuggerEngine Clone()
+        {
+            return new DebuggerEngine(Name, ID, IsSelected);
+        }
+
+        public int CompareTo(DebuggerEngine other)
+        {
+            if (other == null)
+                return 1;
+
+            return StringComparer.OrdinalIgnoreCase.Compare(Name, other.Name);
+        }
+    }
+
+    public class SelectDebuggerEngineDialogModel : ISelectDebuggerEngineDialogModel, INotifyPropertyChanged
+    {
+        public SelectDebuggerEngineDialogModel(DebuggerEngines debuggerEngines)
+        {
+            DebuggerEngines = debuggerEngines?.Clone() ?? throw new ArgumentNullException(nameof(debuggerEngines));
+
+            DebuggerEngines.PropertyChanged += DebuggerEngines_PropertyChanged;
+        }
+
+        public DebuggerEngines DebuggerEngines { get; set; }
+
+        public bool SelectionValid
+        {
+            get
+            {
+                return DebuggerEngines.IsAutomatic || DebuggerEngines.ManuallySelectedEngines.Any();
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void DebuggerEngines_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(SelectionValid)));
+        }
+    }
+
+    public sealed class SelectDebuggerEngineDialogModelDesignSample : ISelectDebuggerEngineDialogModel
+    {
+        public static readonly DebuggerEngine[] SampleEngines =
+        {
+            new DebuggerEngine("Managed (v4.6, v4.5, v4.0) code", "ID0", isSelected: true),
+            new DebuggerEngine("Native", "ID1", isSelected: true),
+            new DebuggerEngine("ABC", "ID2", isSelected: false),
+            new DebuggerEngine("DEF", "ID3", isSelected: false),
+            new DebuggerEngine("GHI", "ID4", isSelected: false),
+            new DebuggerEngine("JKL", "ID5", isSelected: false),
+            new DebuggerEngine("MNO", "ID6", isSelected: false),
+            new DebuggerEngine("PQR", "ID7", isSelected: false),
+            new DebuggerEngine("STU", "ID8", isSelected: false),
+            new DebuggerEngine("VWX", "ID9", isSelected: false),
+            new DebuggerEngine("YZ0", "ID10", isSelected: false),
+        };
+
+        public DebuggerEngines DebuggerEngines { get; set; } = new DebuggerEngines(isAutomatic: false, manualSelection: SampleEngines);
+
+        public bool SelectionValid => false;
+    }
+}

--- a/src/WacVsTools.Core/AttachToWacProcess/SelectDebuggerEngineDialogModel.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/SelectDebuggerEngineDialogModel.cs
@@ -23,11 +23,11 @@
         public const string DefaultDebuggerEngineName = @"Managed (v4.6, v4.5, v4.0) code";
         public const string DefaultDebuggerEngineID = @"{FB0D4648-F776-4980-95F8-BB7F36EBC1EE}";
 
-        private static readonly DebuggerEngines s_default = new DebuggerEngines(isLazy: true, isAutomatic: true, manualSelection: new[] { new DebuggerEngine(DefaultDebuggerEngineName, DefaultDebuggerEngineID, isSelected: false) });
+        private static readonly DebuggerEngines LazyDefault = new DebuggerEngines(isLazy: true, isAutomatic: true, manualSelection: new[] { new DebuggerEngine(DefaultDebuggerEngineName, DefaultDebuggerEngineID, isSelected: false) });
 
-        private readonly bool m_isLazy;
-        private bool m_isAutomatic;
-        private readonly IReadOnlyList<DebuggerEngine> m_manualSelection;
+        private readonly bool isLazy;
+        private bool isAutomatic;
+        private readonly IReadOnlyList<DebuggerEngine> manualSelection;
 
         public DebuggerEngines(bool isAutomatic, IList<DebuggerEngine> manualSelection)
             : this(isLazy: false, isAutomatic: isAutomatic, manualSelection: manualSelection)
@@ -36,11 +36,11 @@
 
         private DebuggerEngines(bool isLazy, bool isAutomatic, IList<DebuggerEngine> manualSelection)
         {
-            m_isLazy = isLazy;
-            IsAutomatic = isAutomatic;
-            m_manualSelection = manualSelection?.ToList() ?? throw new ArgumentNullException(nameof(ManualSelection));
+            this.isLazy = isLazy;
+            this.IsAutomatic = isAutomatic;
+            this.manualSelection = manualSelection?.ToList() ?? throw new ArgumentNullException(nameof(ManualSelection));
 
-            foreach (var debuggerEngine in m_manualSelection)
+            foreach (var debuggerEngine in this.manualSelection)
             {
                 debuggerEngine.PropertyChanged += OnChildPropertyChanged;
             }
@@ -51,19 +51,19 @@
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ManualSelection)));
         }
 
-        public static DebuggerEngines DefaultLazy => s_default;
+        public static DebuggerEngines DefaultLazy => LazyDefault;
 
         public bool IsAutomatic
         {
             get
             {
-                return m_isAutomatic;
+                return isAutomatic;
             }
             set
             {
-                if (m_isAutomatic != value)
+                if (isAutomatic != value)
                 {
-                    m_isAutomatic = value;
+                    isAutomatic = value;
 
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsAutomatic)));
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsManual)));
@@ -111,13 +111,13 @@
         {
             get
             {
-                return !m_isAutomatic;
+                return !isAutomatic;
             }
             set
             {
-                if (m_isAutomatic != !value)
+                if (isAutomatic != !value)
                 {
-                    m_isAutomatic = !value;
+                    isAutomatic = !value;
 
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsAutomatic)));
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsManual)));
@@ -125,11 +125,11 @@
             }
         }
 
-        public bool IsLazy => m_isLazy;
+        public bool IsLazy => isLazy;
 
-        public IReadOnlyList<DebuggerEngine> ManualSelection => m_manualSelection;
+        public IReadOnlyList<DebuggerEngine> ManualSelection => manualSelection;
 
-        public IEnumerable<DebuggerEngine> ManuallySelectedEngines => m_manualSelection.Where(debuggerEngine => debuggerEngine.IsSelected);
+        public IEnumerable<DebuggerEngine> ManuallySelectedEngines => manualSelection.Where(debuggerEngine => debuggerEngine.IsSelected);
 
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -141,16 +141,16 @@
         public DebuggerEngines Clone()
         {
             return new DebuggerEngines(
-                m_isLazy,
-                m_isAutomatic,
-                m_manualSelection
+                isLazy,
+                isAutomatic,
+                manualSelection
                     .Select(debuggerEngine => debuggerEngine.Clone()).ToList());
         }
     }
 
     public sealed class DebuggerEngine : INotifyPropertyChanged, IComparable<DebuggerEngine>
     {
-        private bool m_isSelected;
+        private bool isSelected;
 
         public DebuggerEngine(string name, string id, bool isSelected)
         {
@@ -167,11 +167,11 @@
         {
             get
             {
-                return m_isSelected;
+                return isSelected;
             }
             set
             {
-                m_isSelected = value;
+                isSelected = value;
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected)));
             }
         }

--- a/src/WacVsTools.Core/WacVsTools.Core.csproj
+++ b/src/WacVsTools.Core/WacVsTools.Core.csproj
@@ -48,6 +48,9 @@
     <Reference Include="EnvDTE90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
+    <Reference Include="EnvDTE90a, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.CommandBars, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -151,6 +154,11 @@
     </Compile>
     <Compile Include="AttachToWacProcess\AttachToWacProcessDialogModel.cs" />
     <Compile Include="AttachToWacProcess\AttachToWacProcessMenuCommands.cs" />
+    <Compile Include="AttachToWacProcess\IMenuCommands.cs" />
+    <Compile Include="AttachToWacProcess\SelectDebuggerEngineDialog.xaml.cs">
+      <DependentUpon>SelectDebuggerEngineDialog.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="AttachToWacProcess\SelectDebuggerEngineDialogModel.cs" />
     <Compile Include="Guids.cs" />
     <Compile Include="MenuCommandsBase.cs" />
     <Compile Include="PkgCmdID.cs" />
@@ -164,6 +172,14 @@
     <Page Include="AttachToWacProcess\AttachToWacProcessDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="AttachToWacProcess\Resources.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="AttachToWacProcess\SelectDebuggerEngineDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This includes a new dialog which presents the available engines, similar to the Visual Studio dialog. The default is still to use the default engine.