### PR TITLE
Enable all remote debugging transports available to VS.

### DIFF
--- a/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialog.xaml.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialog.xaml.cs
@@ -82,17 +82,11 @@
 
         private void ConnectionType_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if ((string)ConnectionType.SelectedItem == "Local Machine")
+            model.SelectedConnectionType = ConnectionType.SelectedItem.ToString();
+
+            if ((string)ConnectionType.SelectedItem == "Default")
             {
-                ConnectionTarget.IsEnabled = false;
                 ConnectionTarget.Text = Environment.MachineName;
-                ConnectionTarget.Background = Background.Clone();
-            }
-            else if ((string)ConnectionType.SelectedItem == "Remote Connection")
-            {
-                ConnectionTarget.IsEnabled = true;
-                ConnectionTarget.Text = String.Empty;
-                ConnectionTarget.Background = Brushes.White;
             }
         }
 

--- a/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialogModel.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessDialogModel.cs
@@ -21,14 +21,17 @@
 
         private DebuggerEngines debuggerEngines;
 
-        public AttachToWacProcessDialogModel(IMenuCommands menuCommands)
+        public AttachToWacProcessDialogModel(IMenuCommands menuCommands, IEnumerable<string> connectionTypes)
         {
             MenuCommands = menuCommands ?? throw new ArgumentNullException(nameof(menuCommands));
+            ConnectionTypes = connectionTypes != null ? new ObservableCollection<string>(connectionTypes) : throw new ArgumentNullException(nameof(connectionTypes));
             Processes = new ObservableCollection<WacProcessInfo>();
             DebuggerEngines = DebuggerEngines.DefaultLazy;
         }
 
-        public ObservableCollection<string> ConnectionTypes = new ObservableCollection<string> { "Local Machine", "Remote Connection" };
+        public ObservableCollection<string> ConnectionTypes { get; private set; }
+
+        public string SelectedConnectionType { get; set; }
 
         public string Host { get; set; }
         public string Port { get; set; }

--- a/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessMenuCommands.cs
+++ b/src/WacVsTools.Core/AttachToWacProcess/AttachToWacProcessMenuCommands.cs
@@ -63,8 +63,8 @@
             }
             else
             {
-                Debugger2 debugger = (Debugger2)_dte.Debugger;
-                Transport transport = debugger.Transports.Item("Remote (No Authentication)");
+                var debugger = (Debugger2)_dte.Debugger;
+                Transport transport = debugger.Transports.Item(model.SelectedConnectionType);
                 string transportQualifier = model.Host;
                 if (!string.IsNullOrWhiteSpace(model.Port))
                 {
@@ -86,7 +86,13 @@
 
         private AttachToWacProcessDialogModel ShowWacProcessesList()
         {
-            var model = new AttachToWacProcessDialogModel(this);
+            var connectionTypes = new List<string>();
+            foreach (Transport transport in ((Debugger2)_dte.Debugger).Transports)
+            {
+                connectionTypes.Add(transport.Name);
+            }
+
+            var model = new AttachToWacProcessDialogModel(this, connectionTypes);
             var window = new AttachToWacProcessDialog(model);
             var result = ShowDialog(window);
 

--- a/src/WacVsTools.Test/App.xaml.cs
+++ b/src/WacVsTools.Test/App.xaml.cs
@@ -17,7 +17,7 @@ namespace WacVsTools.Test
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
-            var model = new AttachToWacProcessDialogModel(new TestMenuCommands());
+            var model = new AttachToWacProcessDialogModel(new TestMenuCommands(), new string[] { "Default", "Remote Computer" });
             var window = new AttachToWacProcessDialog(model);
             window.ShowDialog();
         }


### PR DESCRIPTION
#### Proposed changes
Enables all debugging transportation types for WacVSTools.
That is SSH, Windows Auth, Python, Webkit are all supported and future transportation types will be automatically be included.

#### Comments
- I haven't tested the Python transportation type.
- Transportations such as SSH will pop-up additional settings menus when the user tries to connect.
- Default transportation will automatically use the local machine but this is now modifiable to other machines. 
   * Still no change in usage required for those debugging directly in Server.