### PR TITLE
Update the installation target of vs2019 extension

### DIFF
--- a/src/WacVsTools.VS2019/source.extension.vsixmanifest
+++ b/src/WacVsTools.VS2019/source.extension.vsixmanifest
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="WacVsTools.VS2019.Marcin Juraszek.9237d91f-3f1b-4f4f-9693-531ec6ea5125" Version="2.2" Language="en-US" Publisher="Marcin Juraszek" />
+        <Identity Id="WacVsTools.VS2019.Marcin Juraszek.9237d91f-3f1b-4f4f-9693-531ec6ea5125" Version="2.3" Language="en-US" Publisher="Marcin Juraszek" />
         <DisplayName>WacVsTools.VS2019</DisplayName>
         <Description xml:space="preserve">WAC Tools for Visual Studio</Description>
     </Metadata>
     <Installation AllUsers="true">
-        <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[14.0,17.0]" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[16.0,17.0]" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />


### PR DESCRIPTION
Update the installation target of vs2019 extension so that vsixinstaller doesn't attempt to install it to vs2017 in the SxS installation scenario.

Basically when the user has both VS2017 and VS2019 on the same machine, vsixinstaller attempts to install the 2019 version of the extension against both vs2017 and vs2019 and the vs2017 installation fails. I have found the reason for this to be the following entry in the manifest:

        <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[14.0,17.0]" />

As you can see in the PR, I have changed it to 

<InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[16.0,17.0]" />

So that vsixinstaller.exe doesn’t attempt to install it.